### PR TITLE
fix: change theme function to return one class

### DIFF
--- a/src/context/ThemeContex.js
+++ b/src/context/ThemeContex.js
@@ -15,7 +15,7 @@ const ThemeProvider = ({ children }) => {
   }, []);
 
   const theme = (lightThemeClassName, darkThemeClassName) =>
-    `${lightThemeClassName} ${isDarkTheme && darkThemeClassName}`;
+    isDarkTheme ? darkThemeClassName : lightThemeClassName;
 
   return (
     <ThemeContext.Provider value={{ isDarkTheme, toggleTheme, theme }}>


### PR DESCRIPTION
The theme function was always returning light theme classname, which was working up till now, but not every component reacts correctly when both class are added. After this change, only one classname will be used, avoiding the confusion.

As to how create styles that will work fine with theme:
create 3 css classes: base class, light additional class and dark additional class.

`
.component {
property: value;

.light-component{
property-for-light: value;
}

.dark-component{
property-for-dark: value;
}
`